### PR TITLE
修改了av号的获取方式为正则表达式

### DIFF
--- a/play-with-mpv.user.js
+++ b/play-with-mpv.user.js
@@ -858,7 +858,7 @@ class BilibiliHandler extends Handler {
             if (videoId.startsWith("BV")) {
                 param = "bvid=" + videoId.substring(2, 12);
             } else if (videoId.startsWith("av")) {
-                param = "aid=" + videoId.substring(2, 10);
+                param = "aid=" + videoId.split(/av([1-9]\d{6,14})/)[1].substring(2);
             } else {
                 // debug("bilibili video id invalid: " + videoId);
                 return;


### PR DESCRIPTION
b站的av号长度并不是一成不变，长度会不断增加，因此修改了获取av号获取方式为正则表达式，目前写到14位
（至于为什么还用av号，是有一些另外的脚本只能打开av号的视频）