### PR TITLE
mpv自动转换字幕，不依赖于在线转换服务

### DIFF
--- a/bili_sub.lua
+++ b/bili_sub.lua
@@ -25,6 +25,7 @@ function process()
     end
     msg.info('转换为srt字幕...')
     local response_body = utils.parse_json(res.stdout)
+    local lang = response_body.lang
     local title = '哔哩哔哩字幕'
     if response_body.type then title = title .. ' [' .. response_body.type .. ']' end
     local srt_content = ''
@@ -42,7 +43,8 @@ function process()
     file:write(srt_content)
     file:close()
     msg.info('加载srt字幕...')
-    local success = mp.commandv('sub-add', srt_file, 'select', title)
+    local success = lang and mp.commandv('sub-add', srt_file, 'select', title, lang)
+                         or  mp.commandv('sub-add', srt_file, 'select', title)
     msg.info('srt字幕加载' .. (success and '成功' or '失败'))
 end
 

--- a/bili_sub.lua
+++ b/bili_sub.lua
@@ -1,0 +1,57 @@
+-- 下载哔哩哔哩json字幕转换为srt字幕
+-- mpv系列播放器使用，放在~/scripts目录下
+-- 使用方式：启动参数 --scrpit-opts-append=bili_sub-url="https://.............."
+
+local msg = require 'mp.msg'
+local utils = require 'mp.utils'
+local options = require 'mp.options'
+
+local opts = {url = ''}
+options.read_options(opts, _, process)
+
+local srt_file = mp.command_native({'expand-path', '~~cache/'}) .. '/bili_sub.srt'
+function process()
+    if not opts.url or opts.url == '' then return end
+    msg.info('下载字幕: ' .. opts.url)
+    local res = mp.command_native({
+        name = 'subprocess', 
+        capture_stdout = true, 
+        playback_only = false, 
+        args = {'curl', opts.url}
+    })
+    if res.status ~= 0 then
+        msg.warn('字幕下载失败')
+        return 
+    end
+    msg.info('转换为srt字幕...')
+    local response_body = utils.parse_json(res.stdout)
+    local title = '哔哩哔哩字幕'
+    if response_body.type then title = title .. ' [' .. response_body.type .. ']' end
+    local srt_content = ''
+    for i, v in ipairs(response_body.body) do
+        srt_content = srt_content .. i .. '\r\n'
+        srt_content = srt_content .. convert_time(v.from) .. ' --> ' .. convert_time(v.to) .. '\r\n'
+        srt_content = srt_content .. v.content .. '\r\n'
+        srt_content = srt_content .. '\r\n'
+    end
+    local file = io.open(srt_file, 'w')
+    if not file then
+        msg.warn('无法写入字幕文件')
+        return
+    end
+    file:write(srt_content)
+    file:close()
+    msg.info('加载srt字幕...')
+    local success = mp.commandv('sub-add', srt_file, 'select', title)
+    msg.info('srt字幕加载' .. (success and '成功' or '失败'))
+end
+
+-- 秒数转换为srt字幕的时间格式
+-- 例如 79.14 转为 00:01:19,140
+function convert_time(t)
+    local sec = math.floor(t)
+    local mills = math.floor((t - sec) * 1000)
+    return os.date('!%H:%M:%S', sec) .. ',' .. mills
+end
+
+mp.register_event('file-loaded', process)

--- a/bili_sub.lua
+++ b/bili_sub.lua
@@ -1,6 +1,6 @@
 -- 下载哔哩哔哩json字幕转换为srt字幕
--- mpv系列播放器使用，放在~/scripts目录下
--- 使用方式：启动参数 --scrpit-opts-append=bili_sub-url="https://.............."
+-- mpv系列播放器使用，放在~~/scripts目录下
+-- 使用方式：启动参数添加字幕地址 --scrpit-opts-append=bili_sub-url="https://......"
 
 local msg = require 'mp.msg'
 local utils = require 'mp.utils'
@@ -46,6 +46,7 @@ function process()
     local success = lang and mp.commandv('sub-add', srt_file, 'select', title, lang)
                          or  mp.commandv('sub-add', srt_file, 'select', title)
     msg.info('srt字幕加载' .. (success and '成功' or '失败'))
+    mp.unregister_event(process)
 end
 
 -- 秒数转换为srt字幕的时间格式

--- a/play-with-mpv.user.js
+++ b/play-with-mpv.user.js
@@ -222,7 +222,7 @@ const PLAYER = {
         params: {
             videoUrl: 'mpv://"${videoUrl}"',
             audioUrl: ' --audio-file="${audioUrl}"',
-            subtitleUrl: ' --sub-file="${subtitleUrl}"',
+            originalSubtitleUrl: ' --script-opts-append=bili_sub-url="${originalSubtitleUrl}"',
             title: ' --force-media-title="${title}"',
             startTime: " --start=${startTime}",
             referer: ' --http-header-fields="referer: ${referer}"',
@@ -1716,6 +1716,7 @@ class Media {
         this.videoUrl = "";
         this.audioUrl = "";
         this.subtitleUrl = "";
+        this.originalSubtitleUrl = "";
         this.startTime = "";
         this.referer = "";
         this.origin = "";
@@ -1752,6 +1753,9 @@ class Media {
     }
     setSubtitleUrl(subtitleUrl) {
         this.subtitleUrl = subtitleUrl;
+    }
+    setOriginalSubtitleUrl(originalSubtitleUrl) {
+        this.originalSubtitleUrl = originalSubtitleUrl;
     }
     setStartTime(startTime) {
         this.startTime = Math.floor(startTime);
@@ -2158,6 +2162,7 @@ function getBilibiliVideoSubtitle(avid, cid) {
                 handler.media.setSubtitleUrl(
                     `https://www.lckp.top/common/bilibili/jsonToSrt/?url=${url}&lan=${lan}`
                 );
+                handler.media.setOriginalSubtitleUrl(url)
             }
         },
     });


### PR DESCRIPTION
写了个mpv的lua脚本，可通过启动参数添加原始json字幕地址`--scrpit-opts-append=bili_sub-url="https://......"`下载b站的json字幕自动转换为srt字幕，代码很简单就50行左右，懒得再开个仓库维护。
不依赖在线转换服务，本地转换应该更稳定，给服务器也减点压力，上次还出现服务挂掉的情况 #143。
![mpv-shot0001](https://github.com/LuckyPuppy514/Play-With-MPV/assets/45035465/9565b9ed-d0b0-4a61-815c-9b3697b7e248)

js代码修改只是个草稿，只为了确定下可行性，具体要怎么改还是交给你考虑吧，可能要给个开关给用户。
