### PR TITLE
修复youtube无法使用的问题

### DIFF
--- a/play-with-mpv.user.js
+++ b/play-with-mpv.user.js
@@ -126,12 +126,15 @@
 // @match                   https://iframe.mediadelivery.net/*
 // @connect                 api.bilibili.com
 // @connect                 api.live.bilibili.com
-// @require                 https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-y/jquery/3.2.1/jquery.min.js
+// @resource                jquery https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-y/jquery/3.2.1/jquery.min.js
 // @require                 https://lf6-cdn-tos.bytecdntp.com/cdn/expire-1-y/spark-md5/3.0.2/spark-md5.min.js
 // @grant                   GM_setValue
 // @grant                   GM_getValue
+// @grant                   GM_getResourceText
 // @run-at                  document-body
 // ==/UserScript==
+trustedTypes?.createPolicy?.('default', {createScriptURL: s => s, createScript: s => s, createHTML: s => s})
+eval(GM_getResourceText('jquery'))
 
 "use strict";
 


### PR DESCRIPTION
由于jQuery的Trusted Types问题导致脚本无法在youtube上执行，应用如下方案暂时解决该问题
`// @resource                jquery https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-y/jquery/3.2.1/jquery.min.js`
`// @grant                   GM_getResourceText`
`trustedTypes?.createPolicy?.('default', {createScriptURL: s => s, createScript: s => s, createHTML: s => s})`
`eval(GM_getResourceText('jquery'))`